### PR TITLE
Fixing bug on KeyRealease Events

### DIFF
--- a/GreenTea/src/GreenTea/Events/EventRegistry.h
+++ b/GreenTea/src/GreenTea/Events/EventRegistry.h
@@ -275,7 +275,7 @@ namespace GTE {
 			EventRegistry& reg = EventRegistry::Get();
 			reg.MapListener(obj_ptr, GTE::EventType::KeyReleased);
 
-			entt::delegate<bool(char)> temp{};
+			entt::delegate<bool(KeyCode)> temp{};
 			temp.connect<Fn>(obj_ptr);
 			reg.m_KeycodeCallbacks[EventType::KeyReleased].push_back(temp);
 		}


### PR DESCRIPTION
I tried creating a function to handle KeyRealease Event. And I notice bug.
Changing in EventRegistry.h line 278 from: 
```
entt::delegate<bool(char)> temp{};
```
to :
```
entt::delegate<bool(KeyCode)> temp{};
```
Fixed it.